### PR TITLE
Feat: changed example to reflect chakra typography

### DIFF
--- a/frontend-styleguide/README.md
+++ b/frontend-styleguide/README.md
@@ -421,12 +421,12 @@ export const MyComponent = (): React.ReactElement => {
   return (
     <Flex>
       <Box mb="1rem">
-        <Heading p="0.5rem" fontSize="0.75rem">
+        <Heading p="0.5rem" fontSize="1rem">
           Title
         </Heading>
       </Box>
       <Box>
-        <Text fontSize="0.25rem">SubTitle</Text>
+        <Text fontSize="0.75rem">SubTitle</Text>
       </Box>
     </Flex>
   );
@@ -440,12 +440,12 @@ export const MyComponent = (): React.ReactElement => {
   return (
     <Flex>
       <Box mb={4}>
-        <Heading p={2} fontSize={3}>
+        <Heading p={2} fontSize="md">
           Title
         </Heading>
       </Box>
       <Box>
-        <Text fontSize={1}>SubTitle</Text>
+        <Text fontSize="xs">SubTitle</Text>
       </Box>
     </Flex>
   );


### PR DESCRIPTION
Simple change at the example of chakra typography usage, to match real values:

![image](https://user-images.githubusercontent.com/92101100/153063251-4cb4425b-e74b-4863-9ec3-229ba86b560f.png)

https://chakra-ui.com/docs/theming/theme#typography